### PR TITLE
Mock API call

### DIFF
--- a/Tests/New-HipchatUser.Tests.ps1
+++ b/Tests/New-HipchatUser.Tests.ps1
@@ -7,23 +7,19 @@ Describe "New-HipchatUser" {
             
             It 'Attempts to invoke web api' {
                 Mock Invoke-WebRequest -MockWith {
-                    $request = @{'id' = '123456';
+                    $returned = @{'id' = '123456';
                                 'Content' = 'someContent';
                                 'Status' = 'someStatus';
                                 'StatusCode' = '201'
                                 }
-                    return $request
+                    return $returned
                 }
-                $global:result = New-HipchatUser -FirstName 'Pester' -LastName 'Test' -ApiToken $ApiToken
+                $global:result = New-HipchatUser -FirstName 'Pester' -LastName 'Test' -ApiToken 'REXsCauSe553gsoIJg1Gj4zwNsSAwS'
+                Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 1 -Scope It
             }
             
-            It 'Should be mocked' {
-                $MockParams = @{
-                    CommandName = 'Invoke-WebRequest'
-                    Times = 1
-                    Exactly = $true
-                }
-                Assert-MockCalled @MockParams
+            It 'StatusCode field exists and not null' {
+                $result.StatusCode.ToString() | Should Not Be $null
             }
             
             It "Should return a 201 Status Code" {

--- a/Tests/New-HipchatUser.Tests.ps1
+++ b/Tests/New-HipchatUser.Tests.ps1
@@ -1,4 +1,5 @@
-﻿Import-Module PHipChatAdmin
+Get-Module HipChatAdmin | Remove-Module -Force
+Import-Module $PSScriptRoot\..\HipChatAdmin\HipChatAdmin.psm1
 
 Describe "New-HipchatUser" {
     InModuleScope HipChatAdmin {
@@ -14,7 +15,7 @@ Describe "New-HipchatUser" {
                                 }
                     return $returned
                 }
-                $global:result = New-HipchatUser -FirstName 'Pester' -LastName 'Test' -ApiToken 'REXsCauSe553gsoIJg1Gj4zwNsSAwS'
+                $global:result = New-HipchatUser -FirstName 'Pester' -LastName 'Test' -EmailAddress 'test@nomatter.com' -ApiToken 'REXsCauSe553gsoIJg1Gj4zwNsSAwS'
                 Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 1 -Scope It
             }
             

--- a/Tests/New-HipchatUser.Tests.ps1
+++ b/Tests/New-HipchatUser.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿Import-Module PHipChatAdmin
 
 Describe "New-HipchatUser" {
-    InModuleScope PHipChatAdmin {
+    InModuleScope HipChatAdmin {
         
         Context "When the API call is sent" {
             

--- a/Tests/New-HipchatUser.Tests.ps1
+++ b/Tests/New-HipchatUser.Tests.ps1
@@ -1,16 +1,36 @@
 ﻿Import-Module PHipChatAdmin
 
 Describe "New-HipchatUser" {
-
-    Context "When the API call is sent" {
-
-        It "Should return a 201 Status Code" {
-            New-HipchatUser -FirstName 'Pester' -LastName 'Test' -ApiToken $ApiToken | 
-            Should Be '201'
+    InModuleScope PHipChatAdmin {
+        
+        Context "When the API call is sent" {
+            
+            It 'Attempts to invoke web api' {
+                Mock Invoke-WebRequest -MockWith {
+                    $request = @{'id' = '123456';
+                                'Content' = 'someContent';
+                                'Status' = 'someStatus';
+                                'StatusCode' = '201'
+                                }
+                    return $request
+                }
+                $global:result = New-HipchatUser -FirstName 'Pester' -LastName 'Test' -ApiToken $ApiToken
+            }
+            
+            It 'Should be mocked' {
+                $MockParams = @{
+                    CommandName = 'Invoke-WebRequest'
+                    Times = 1
+                    Exactly = $true
+                }
+                Assert-MockCalled @MockParams
+            }
+            
+            It "Should return a 201 Status Code" {
+                $result.StatusCode.ToString() | Should Be '201'
+            }
         }
-    }
 
-    AfterAll {
-        Remove-HipchatUser -MentionName 'PesterTest'
     }
+    
 }


### PR DESCRIPTION
First pass at mocking Invoke-WebRequest so API calls are simulated. I've cobbled this together but haven't yet tested. If @cofonseca can test and confirm it's working, then it can be expanded to other Pester tests with Invoke-WebRequest commands.