### PR TITLE
Example error handling for Invoke-WebRequest

### DIFF
--- a/HipChatAdmin/Public/New-HipchatUser.ps1
+++ b/HipChatAdmin/Public/New-HipchatUser.ps1
@@ -67,13 +67,21 @@ function New-HipchatUser{
 		Write-Verbose "Sending $Body to HipChat API"
 
 		# Send API Request #
-		$Call = (
-			Invoke-WebRequest `
-				-Uri "https://api.hipchat.com/v2/user?auth_token=$ApiToken" `
-				-Method POST `
-				-ContentType "application/json" `
-				-Body (ConvertTo-Json $Body)
-		)
+		try {
+			$Call = (
+				Invoke-WebRequest `
+					-Uri "https://api.hipchat.com/v2/user?auth_token=$ApiToken" `
+					-Method POST `
+					-ContentType "application/json" `
+					-Body (ConvertTo-Json $Body)
+			)
+		}
+		catch {
+			Write-Output "Caught an exception:"
+			Write-Output "Exception Type: $($_.Exception.GetType().FullName)"
+			Write-Output "Exception Message: $($_.Exception.Message)"
+			Exit 1
+		}
 
 	}
 


### PR DESCRIPTION
Added a try-catch block around Invoke-WebRequest as an example for possible error handling. It adds a lot of extra code without necessarily lots of benefit, so repo owner should weigh its importance. Example code from http://docs.usetrace.com/ci/bamboo/.